### PR TITLE
Fix PHP 8.2 deprecation notice.

### DIFF
--- a/mimemail.module
+++ b/mimemail.module
@@ -156,7 +156,10 @@ function mimemail_mail($key, &$message, $params) {
 
   // Prepare the array of the attachments.
   $attachments = array();
-  $attachments_string = trim($params['attachments']);
+  $attachments_string = null;
+  if (!empty($params['attachments'])) {
+    $attachments_string = trim($params['attachments']);
+  }
   if (!empty($attachments_string)) {
     $attachment_lines = array_filter(explode("\n", trim($attachments_string)));
     foreach ($attachment_lines as $filepath) {


### PR DESCRIPTION
Check if there is an 'attachments' string in $params before setting the attachment string.

Closes #57